### PR TITLE
Pq 36 : 카카오 로그인 회원가입 추가 및 로컬 성공

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
-VITE_APP_ORIGIN=https://pqsoft.net
+VITE_APP_ORIGIN=https://api.pqsoft.net
+VITE_APP_ORIGIN_USER=https://api.pqsoft.net

--- a/src/apis/instance/axiosInstance.ts
+++ b/src/apis/instance/axiosInstance.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import Cookies from 'js-cookie';
-import { URL } from 'src/constants/apiUrl';
+import { CHAT_URL } from 'src/constants/apiUrl';
 import handleError from 'src/utils/handleError';
 
 /**
@@ -8,7 +8,7 @@ import handleError from 'src/utils/handleError';
  */
 
 const axiosInstance = axios.create({
-  baseURL: URL.BASE,
+  baseURL: CHAT_URL.BASE,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/components/sign/button/SocialButton.tsx
+++ b/src/components/sign/button/SocialButton.tsx
@@ -9,9 +9,9 @@ interface SocialButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   children?: ReactNode;
 }
 
-export default function SocialButton({ variant, src, children }: SocialButtonProps) {
+export default function SocialButton({ variant, src, children, ...rest }: SocialButtonProps) {
   return (
-    <Button type='button' $variant={variant}>
+    <Button type='button' $variant={variant} {...rest}>
       <SocialLogo src={src} alt={`${variant} 아이콘`} />
       {children}
       <span></span>

--- a/src/constants/apiKey.ts
+++ b/src/constants/apiKey.ts
@@ -1,0 +1,1 @@
+export const KAKAO_CLIENT_ID = import.meta.env.VITE_APP_KAKAO_CLIENT_ID;

--- a/src/constants/apiUrl.ts
+++ b/src/constants/apiUrl.ts
@@ -1,7 +1,13 @@
-export const URL = {
-  BASE: import.meta.env.VITE_APP_ORIGIN,
+export const CHAT_URL = {
+  BASE: import.meta.env.VITE_APP_ORIGIN_CHAT,
+  SERVER: '/chat/v1/server',
+};
 
-  SERVER: 'chat/v1/server',
+export const USER_URL = {
+  BASE: import.meta.env.VITE_APP_ORIGIN_USER,
   USER: '/user/v1/user',
   AUTH: '/user/v1/auth',
 };
+
+export const LOGIN_REDIRECT = import.meta.env.VITE_APP_LOGIN_REDIRECT_URI;
+export const SIGNUP_REDIRECT = import.meta.env.VITE_APP_SIGNUP_REDIRECT_URI;

--- a/src/hooks/useCheckEmail.ts
+++ b/src/hooks/useCheckEmail.ts
@@ -2,13 +2,13 @@ import { AxiosError } from 'axios';
 import { UseFormSetError } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { useMutationPost } from 'src/apis/service/service';
-import { URL } from 'src/constants/apiUrl';
+import { USER_URL } from 'src/constants/apiUrl';
 import { ERROR_MESSAGES } from 'src/constants/error';
 import { FormValues } from 'src/pages/signup/_types/type';
 
 export const useCheckEmail = (setError: UseFormSetError<FormValues>) => {
   const navigate = useNavigate();
-  const { mutate, isPending } = useMutationPost(`${URL.AUTH}/signup/confirm`, {
+  const { mutate, isPending } = useMutationPost(`${USER_URL.AUTH}/signup/confirm`, {
     onError: (error: unknown) => {
       const axiosError = error as AxiosError;
       const status = axiosError?.response?.status;

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -5,13 +5,13 @@ import { ERROR_MESSAGES } from 'src/constants/error';
 import { FormValues } from 'src/pages/signup/_types/type';
 import Cookies from 'js-cookie';
 import { useMutationPost } from 'src/apis/service/service';
-import { URL } from 'src/constants/apiUrl';
+import { USER_URL } from 'src/constants/apiUrl';
 import { LoginRequest, LoginResponse, LoginResponseBody } from 'src/pages/login/_type/type';
 
 export const useLogin = (setError: UseFormSetError<FormValues>) => {
   const navigate = useNavigate();
 
-  const { data, mutate, isPending } = useMutationPost<LoginResponse, LoginRequest>(`${URL.AUTH}/login`, {
+  const { data, mutate, isPending } = useMutationPost<LoginResponse, LoginRequest>(`${USER_URL.AUTH}/login`, {
     onError: (error: unknown) => {
       const axiosError = error as AxiosError;
       const status = axiosError?.response?.status;

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -4,11 +4,11 @@ import { FormValues, SignupRequest, SignupResponse } from 'src/pages/signup/_typ
 import { UseFormSetError } from 'react-hook-form';
 import { AxiosError } from 'axios';
 import { useMutationPost } from 'src/apis/service/service';
-import { URL } from 'src/constants/apiUrl';
+import { USER_URL } from 'src/constants/apiUrl';
 
 export const useSignup = (setError: UseFormSetError<FormValues>) => {
   const navigate = useNavigate();
-  const { mutate, isPending } = useMutationPost<SignupResponse, SignupRequest>(`${URL.AUTH}/signup`, {
+  const { mutate, isPending } = useMutationPost<SignupResponse, SignupRequest>(`${USER_URL.AUTH}/signup`, {
     onError: (error: unknown) => {
       const axiosError = error as AxiosError;
       const status = axiosError?.response?.status;

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -38,9 +38,9 @@ export default function Login() {
         }
         if (e.response?.status === 404) {
           alert('존재하지 않는 유저입니다.');
-          navigate('/login');
           return;
         }
+        navigate('/login');
       }
 
       // 여기에 이제 카카오 로그인 되었을 때 처리 (상태관리, 리다이렉트 등등)

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,15 +1,18 @@
 import SocialButtons from './_components/SocialButtons';
 import { useEffect, useState } from 'react';
 import EmailLogin from './EmailLogin';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import Line from 'src/components/sign/Line';
 import Header from 'src/components/sign/Header';
 import { Area, Container, Button, Prompt } from 'src/components/sign/CommonStyles';
-import axios from 'axios';
+
 import { USER_URL } from 'src/constants/apiUrl';
+import axiosInstance from 'src/apis/instance/axiosInstance';
+import { AxiosError } from 'axios';
 
 export default function Login() {
   const [isEmailLogin, setIsEmailLogin] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     (async () => {
@@ -18,8 +21,28 @@ export default function Login() {
       if (!code) {
         return;
       }
-      const res = await axios.get(`${USER_URL.BASE}${USER_URL.AUTH}/kakao/login?code=${code}`);
-      console.log(res);
+      try {
+        const res = await axiosInstance.get(`${USER_URL.AUTH}/kakao/login?code=${code}`);
+        console.log(res);
+        navigate('/server');
+      } catch (error) {
+        const e = error as AxiosError;
+        if (e.response?.status === 403) {
+          const email = (e.response.data as { email: string })['email'];
+          console.log(email);
+          // 이메일 상태 관리 하기
+          localStorage.setItem('email', email);
+          alert('인증해주세요.');
+          navigate('/checkEmail');
+          return;
+        }
+        if (e.response?.status === 404) {
+          alert('존재하지 않는 유저입니다.');
+          navigate('/login');
+          return;
+        }
+      }
+
       // 여기에 이제 카카오 로그인 되었을 때 처리 (상태관리, 리다이렉트 등등)
     })();
   }, []);

--- a/src/pages/login/Login.tsx
+++ b/src/pages/login/Login.tsx
@@ -1,13 +1,28 @@
 import SocialButtons from './_components/SocialButtons';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import EmailLogin from './EmailLogin';
 import { Link } from 'react-router-dom';
 import Line from 'src/components/sign/Line';
 import Header from 'src/components/sign/Header';
 import { Area, Container, Button, Prompt } from 'src/components/sign/CommonStyles';
+import axios from 'axios';
+import { USER_URL } from 'src/constants/apiUrl';
 
 export default function Login() {
   const [isEmailLogin, setIsEmailLogin] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      console.log('시작');
+      const code = new URL(window.location.href).searchParams.get('code');
+      if (!code) {
+        return;
+      }
+      const res = await axios.get(`${USER_URL.BASE}${USER_URL.AUTH}/kakao/login?code=${code}`);
+      console.log(res);
+      // 여기에 이제 카카오 로그인 되었을 때 처리 (상태관리, 리다이렉트 등등)
+    })();
+  }, []);
 
   const renderContent = () => {
     if (isEmailLogin) {

--- a/src/pages/login/_components/SocialButtons.tsx
+++ b/src/pages/login/_components/SocialButtons.tsx
@@ -1,13 +1,21 @@
 import styled from 'styled-components';
 import SocialButton from 'src/components/sign/button/SocialButton';
+import { KAKAO_CLIENT_ID } from 'src/constants/apiKey';
+import { LOGIN_REDIRECT } from 'src/constants/apiUrl';
 
 export default function SocialButtons() {
+  const handleKakaoLogin = () => {
+    const kakaoUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${LOGIN_REDIRECT}&response_type=code`;
+    console.log('kakao login');
+    window.location.href = kakaoUrl;
+  };
+
   return (
     <SocialContainer>
       <SocialButton variant='google' src='/images/google.png'>
         구글로 로그인하기
       </SocialButton>
-      <SocialButton variant='kakao' src='/images/kakao.png'>
+      <SocialButton onClick={handleKakaoLogin} variant='kakao' src='/images/kakao.png'>
         카카오로 로그인하기
       </SocialButton>
     </SocialContainer>

--- a/src/pages/signup/Signup.tsx
+++ b/src/pages/signup/Signup.tsx
@@ -1,15 +1,18 @@
 import SocialButtons from './_components/SocialButtons';
 import EmailSignup from './EmailSignup';
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import Line from 'src/components/sign/Line';
 import Header from 'src/components/sign/Header';
 import { Area, Container, Button, Prompt } from 'src/components/sign/CommonStyles';
 import { USER_URL } from 'src/constants/apiUrl';
-import axios from 'axios';
+
+import axiosInstance from 'src/apis/instance/axiosInstance';
+import { AxiosError } from 'axios';
 
 export default function Signup() {
   const [isEmailSignup, setIsEmailSignup] = useState(false);
+  const navigate = useNavigate();
   useEffect(() => {
     (async () => {
       console.log('시작');
@@ -17,9 +20,22 @@ export default function Signup() {
       if (!code) {
         return;
       }
-      const res = await axios.get(`${USER_URL.BASE}${USER_URL.AUTH}/kakao/signup?code=${code}`);
-      console.log(res);
-      // 여기에 이제 카카오 로그인 되었을 때 처리 (상태관리, 리다이렉트 등등)
+      try {
+        const res = await axiosInstance.get(`${USER_URL.AUTH}/kakao/signup?code=${code}`);
+        //이메일 넣기
+        const email = res.data.email;
+        console.log(email);
+        navigate('/checkEmail');
+      } catch (error) {
+        const e = error as AxiosError;
+        console.log(e);
+        if (e.response?.status === 409) {
+          alert('이미 가입된 회원입니다.');
+          navigate('/login');
+          return;
+        }
+        navigate('/signup');
+      }
     })();
   }, []);
 

--- a/src/pages/signup/Signup.tsx
+++ b/src/pages/signup/Signup.tsx
@@ -1,13 +1,27 @@
 import SocialButtons from './_components/SocialButtons';
 import EmailSignup from './EmailSignup';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Line from 'src/components/sign/Line';
 import Header from 'src/components/sign/Header';
 import { Area, Container, Button, Prompt } from 'src/components/sign/CommonStyles';
+import { USER_URL } from 'src/constants/apiUrl';
+import axios from 'axios';
 
 export default function Signup() {
   const [isEmailSignup, setIsEmailSignup] = useState(false);
+  useEffect(() => {
+    (async () => {
+      console.log('시작');
+      const code = new URL(window.location.href).searchParams.get('code');
+      if (!code) {
+        return;
+      }
+      const res = await axios.get(`${USER_URL.BASE}${USER_URL.AUTH}/kakao/signup?code=${code}`);
+      console.log(res);
+      // 여기에 이제 카카오 로그인 되었을 때 처리 (상태관리, 리다이렉트 등등)
+    })();
+  }, []);
 
   const renderContent = () => {
     if (isEmailSignup) {

--- a/src/pages/signup/_components/SocialButtons.tsx
+++ b/src/pages/signup/_components/SocialButtons.tsx
@@ -1,13 +1,20 @@
 import styled from 'styled-components';
 import SocialButton from 'src/components/sign/button/SocialButton';
+import { SIGNUP_REDIRECT } from 'src/constants/apiUrl';
+import { KAKAO_CLIENT_ID } from 'src/constants/apiKey';
 
 export default function SocialButtons() {
+  const handleKakaoSignup = () => {
+    const kakaoUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_CLIENT_ID}&redirect_uri=${SIGNUP_REDIRECT}&response_type=code`;
+    console.log('kakao login');
+    window.location.href = kakaoUrl;
+  };
   return (
     <SocialContainer>
       <SocialButton variant='google' src='/images/google.png'>
         구글로 가입하기
       </SocialButton>
-      <SocialButton variant='kakao' src='/images/kakao.png'>
+      <SocialButton onClick={handleKakaoSignup} variant='kakao' src='/images/kakao.png'>
         카카오로 가입하기
       </SocialButton>
     </SocialContainer>

--- a/src/pages/signup/_types/type.ts
+++ b/src/pages/signup/_types/type.ts
@@ -27,3 +27,10 @@ interface EmailVerifyStatus {
 
 export type EmailVerifyRequest = EmailVerify;
 export type EmailVerifyResponse = EmailVerifyStatus | null;
+
+export interface KakaoSignupRequest {
+  id: number;
+  email: string;
+  nickname: string;
+  state?: string;
+}


### PR DESCRIPTION
- 한번만 요청함으로 axios 사용했음. 
- 카카오 로그인 성공 시 회원가입 성공시 이메일 상태관리 해야 함.
- 카카오 로그인 실패시 2가지 alert 시킴 (이메일이 존재하지 않을 경우, 성공했지만 이메일 인증이 안된경우)
- 인증 안된 경우 이메일 인증 페이지로 이동
- 카카오 회원가입 실패시 (이미 가입 된 회원경우 로그인 페이지로 이동)
- s3에 환경변수 설정해야함